### PR TITLE
feat(test): make better jest test

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,5 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
-  setupFilesAfterEnv: ['./test/unit/setup.ts'],
-  roots: ['test/unit/']
-};
+  roots: ['test/unit/'],
+}

--- a/test/unit/routes/healthcheck.spec.ts
+++ b/test/unit/routes/healthcheck.spec.ts
@@ -1,38 +1,45 @@
 import * as request from 'supertest'
 import app from '../../../src/server/config'
 
-import { Client } from 'pg';
+import { runQuery } from '../../../src/db/psql'
+
+jest.mock('../../../src/db/psql')
 
 describe('/healthcheck', () => {
   afterEach(() => {
     jest.clearAllMocks()
   })
 
+  const query = runQuery as jest.Mock
+
   it('returns a 200 and an OK response', async () => {
-    const client: any = new Client()
-    client.query.mockResolvedValueOnce({ rows: [{message: 'OK'}], rowCount: 1 });
+    query.mockResolvedValueOnce({
+      rows: [{ message: 'OK' }],
+      rowCount: 1,
+    })
 
     await request(app)
       .get('/healthcheck')
       .set('Accept', 'application/json')
       .expect('Content-Type', /json/)
       .expect(200)
-      .then(response => {
+      .then((response) => {
         expect(response.body.healthstatus).toBe('OK')
       })
   })
 
   it('returns a 200 and an ERROR response', async () => {
-    const client: any = new Client()
-    client.query.mockRejectedValueOnce('boom')
+    query.mockRejectedValueOnce('boom')
 
     await request(app)
       .get('/healthcheck')
       .set('Accept', 'application/json')
       .expect('Content-Type', /json/)
       .expect(200)
-      .then(response => {
-        expect(response.body.healthstatus).toBe('ERROR: DB healthcheck not confirmed')
+      .then((response) => {
+        expect(response.body.healthstatus).toBe(
+          'ERROR: DB healthcheck not confirmed'
+        )
       })
   })
 })

--- a/test/unit/setup.ts
+++ b/test/unit/setup.ts
@@ -1,8 +1,0 @@
-jest.mock('pg', () => {
-  const mClient = {
-    connect: jest.fn(),
-    query: jest.fn(),
-    end: jest.fn(),
-  }
-  return { Client: jest.fn(() => mClient) }
-})


### PR DESCRIPTION
## What's new ?

I think it is better to directly mock the `runQuery` function instead of mocking the entire `pg` dependencies the file `test/unit/setup.js`.*

It allows to : 
- get auto completion for the runQuery `jest.fn()` (which i think is a game changer) 
- remove the `const client = new Client()` in each `it()` function of the tests
- A better understanding of what's hapenning in the test because you use the `runQuery` function in your services




## Idea to improve

Instead of using relative url to import and mock the `runQuery` function like this : 

```ts
import { runQuery } from '../../../src/db/psql'

jest.mock('../../../src/db/psql')
```

We could add [path](https://www.typescriptlang.org/docs/handbook/module-resolution.html#path-mapping) in the `tsconfig.json` to make it easier, like this for example : 

```ts
import { runQuery } from '@psql'

jest.mock('@psql')
```